### PR TITLE
Rename method with name collision

### DIFF
--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -35,7 +35,7 @@ class BlogController extends PageController
         $month = $request->param('Month');
 
 
-        $this->blogPosts = $this->getArchives();
+        $this->blogPosts = $this->getArchivesByDate();
 
         if (!$this->blogPosts->count()) {
             return $this->httpError(404);
@@ -60,7 +60,7 @@ class BlogController extends PageController
      * @param null
      * @return ArrayList
      */
-    public function getArchives()
+    public function getArchivesByDate()
     {
         $year = $this->request->param('Year');
         $month = $this->request->param('Month');


### PR DESCRIPTION
Both `Axllent\Weblog\Model\Blog` and `Axllent\Weblog\Model\BlogController` have methods named "getArchives". This name collision prevents templates from calling the method from Blog (the one from BlogController masks it). Rename the one in BlogController because it is used only once, in the viewArchive method of BlogController.